### PR TITLE
add: test_Qgas

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -130,9 +130,9 @@ class CO2_HITEMP:
             "chunksize": "auto",
             "broadening_max_width": 10,
             "path": [
-                r"D:\Dropbox\Data ECP\14_Databases\CDSD-HITEMP\cdsd_hitemp_07",
-                r"D:\Dropbox\Data ECP\14_Databases\CDSD-HITEMP\cdsd_hitemp_08",
-                r"D:\Dropbox\Data ECP\14_Databases\CDSD-HITEMP\cdsd_hitemp_09",
+                r"/home/gaganaryan/cdsd-hitemp/cdsd_hitemp_07",
+                r"/home/gaganaryan/cdsd-hitemp/cdsd_hitemp_08",
+                r"/home/gaganaryan/cdsd-hitemp/cdsd_hitemp_09",
             ],
             "use_cached": True,
             "dbformat": "cdsd-hitemp",

--- a/manual_benchmarks/test_Qgas.ipynb
+++ b/manual_benchmarks/test_Qgas.ipynb
@@ -1,0 +1,430 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.8.8"
+    },
+    "colab": {
+      "name": "test_Qgas.ipynb",
+      "provenance": []
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "RKYt34MsaPF2"
+      },
+      "source": [
+        "### Import Stuff"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "JD85_N03aPF5"
+      },
+      "source": [
+        "!pip install radis\n",
+        "!pip install memory_profiler\n",
+        "\n",
+        "from radis.db.classes import get_molecule_identifier\n",
+        "from radis.levels.partfunc import PartFuncHAPI\n",
+        "\n",
+        "from radis.io.hitemp import fetch_hitemp\n",
+        "from radis.db.classes import get_molecule\n",
+        "from radis.phys.constants import hc_k\n",
+        "\n",
+        "import numpy as np\n",
+        "from numpy import exp, pi\n",
+        "\n",
+        "%load_ext memory_profiler"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "GkE4FvqfaPF9"
+      },
+      "source": [
+        "### Function to retrieve Qgas value from partition table"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "CUzU_fr8aPF-"
+      },
+      "source": [
+        "def get_Qgas(molecule, iso, T):\n",
+        "\n",
+        "    M = get_molecule_identifier(molecule)\n",
+        "\n",
+        "    Q = PartFuncHAPI(M, iso)\n",
+        "    return Q.at(T=T)"
+      ],
+      "execution_count": 62,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ki3eQhkCsgG3"
+      },
+      "source": [
+        "### Convert list to dictionary "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "1iAPRxWwsjN3"
+      },
+      "source": [
+        "def list_to_dict(list0):\n",
+        "\n",
+        "  dict0 = dict() \n",
+        "  for index,value in enumerate(list0):\n",
+        "    dict0[index] = value\n",
+        "  \n",
+        "  return dict0"
+      ],
+      "execution_count": 63,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "znJSfCjzaPGA"
+      },
+      "source": [
+        "### Old function to used to scale linestrength values "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "nzdCcKeKaPGB"
+      },
+      "source": [
+        "def calc_linestrength_eq(df, Tref, Tgas):\n",
+        "  if len(df) == 0:\n",
+        "          return\n",
+        "\n",
+        "    \n",
+        "  print(\"Scaling equilibrium linestrength\")\n",
+        "\n",
+        "  # %% Load partition function values\n",
+        "\n",
+        "  def _calc_Q(molecule, iso, T_ref, T_gas):\n",
+        "\n",
+        "      Qref = get_Qgas(molecule, iso, T_ref)\n",
+        "      Qgas = get_Qgas(molecule, iso, T_gas)\n",
+        "\n",
+        "\n",
+        "      return Qref, Qgas\n",
+        "\n",
+        "  id_set = df.id.unique()\n",
+        "  id = list(id_set)[0]\n",
+        "  molecule = get_molecule(id) # retrieve the molecule\n",
+        "  iso_set = set(df.iso)  # df1.iso.unique()\n",
+        "\n",
+        "  # when we have only one isotope Qref, Qgas are stored as attributes\n",
+        "  if len(iso_set) == 1:\n",
+        "      Qref, Qgas = _calc_Q(molecule, iso_set[0], T_gas, T_ref)\n",
+        "      df.Qref = float(Qref) \n",
+        "      df.Qgas = float(Qgas)\n",
+        "      assert \"Qref\" not in df.columns\n",
+        "      assert \"Qgas\" not in df.columns\n",
+        "\n",
+        "  # when we have more than one isotope Qref, Qgas are stored as separate columns\n",
+        "  else:\n",
+        "\n",
+        "      iso_arr = list(range(max(iso_set) + 1))\n",
+        "\n",
+        "      Qref_arr = np.empty_like(iso_arr, dtype=np.float64)\n",
+        "      Qgas_arr = np.empty_like(iso_arr, dtype=np.float64)\n",
+        "      for iso in iso_arr:\n",
+        "          if iso in iso_set:\n",
+        "              Qref, Qgas = _calc_Q(molecule, iso, Tref, Tgas)\n",
+        "              Qref_arr[iso] = Qref\n",
+        "              Qgas_arr[iso] = Qgas\n",
+        "\n",
+        "      df[\"Qref\"] = Qref_arr.take(df.iso)\n",
+        "      df[\"Qgas\"] = Qgas_arr.take(df.iso)\n",
+        "\n",
+        "  # Scaling linestrength with the equations from Rotham's paper\n",
+        "  line_strength = df.int * (df.Qref / df.Qgas)\n",
+        "  #line_strength = df.int * (Qref_arr.take(df.iso) / Qgas_arr.take(df.iso))\n",
+        "  line_strength *= exp(-hc_k * df.El * (1 / Tgas - 1 / Tref))\n",
+        "  line_strength *= (1 - exp(-hc_k * df.wav / Tgas)) / (\n",
+        "      1 - exp(-hc_k * df.wav / Tref)\n",
+        "  )\n",
+        "  # Add a fresh columns with the scaled linestrength\n",
+        "  df[\"S\"] = line_strength  # [cm-1/(molecules/cm-2)]\n",
+        "\n",
+        "  # Just to make sure linestrength is indeed added\n",
+        "  assert \"S\" in df\n",
+        "\n",
+        "  return df"
+      ],
+      "execution_count": 64,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "LzhJdIvspSAb"
+      },
+      "source": [
+        "### Scale linstrengths with the new method"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "jEA_RYPApZPZ"
+      },
+      "source": [
+        "def calc_linestrength_eq_optimised(df, Tref, Tgas):\n",
+        "  if len(df) == 0:\n",
+        "          return\n",
+        "\n",
+        "  if \"Qref\" in df:\n",
+        "    print(\"yes Qref here\")\n",
+        "  \n",
+        "  else:\n",
+        "    print(\"not Qref here\")\n",
+        "\n",
+        "    \n",
+        "  print(\"Scaling equilibrium linestrength\")\n",
+        "\n",
+        "  # %% Load partition function values\n",
+        "\n",
+        "  def _calc_Q(molecule, iso, T_ref, T_gas):\n",
+        "\n",
+        "      Qref = get_Qgas(molecule, iso, T_ref)\n",
+        "      Qgas = get_Qgas(molecule, iso, T_gas)\n",
+        "\n",
+        "\n",
+        "      return Qref, Qgas\n",
+        "\n",
+        "  id_set = df.id.unique()\n",
+        "  id = list(id_set)[0]\n",
+        "  molecule = get_molecule(id) # retrieve the molecule\n",
+        "  iso_set = set(df.iso)  # df1.iso.unique()\n",
+        "\n",
+        "  # when we have only one isotope Qref, Qgas are stored as attributes\n",
+        "  if len(iso_set) == 1:\n",
+        "      Qref, Qgas = _calc_Q(molecule, iso_set[0], T_gas, T_ref)\n",
+        "      df.Qref = float(Qref) \n",
+        "      df.Qgas = float(Qgas)\n",
+        "      assert \"Qref\" not in df.columns\n",
+        "      assert \"Qgas\" not in df.columns\n",
+        "\n",
+        "  # when we have more than one isotope Qref, Qgas are stored as separate columns\n",
+        "  else:\n",
+        "\n",
+        "      iso_arr = list(range(max(iso_set) + 1))\n",
+        "\n",
+        "      Qref_arr = np.empty_like(iso_arr, dtype=np.float64)\n",
+        "      Qgas_arr = np.empty_like(iso_arr, dtype=np.float64)\n",
+        "      for iso in iso_arr:\n",
+        "          if iso in iso_set:\n",
+        "              Qref, Qgas = _calc_Q(molecule, iso, Tref, Tgas)\n",
+        "              Qref_arr[iso] = Qref\n",
+        "              Qgas_arr[iso] = Qgas\n",
+        "      \n",
+        "      # convert dictionaries to lists\n",
+        "      Qref_dict = list_to_dict(Qref_arr)\n",
+        "      Qgas_dict = list_to_dict(Qgas_arr)\n",
+        "\n",
+        "      ratio = {k: Qref_dict.get(k, 0) / Qgas_dict.get(k, 0) for k in set(Qref_dict) | set(Qgas_dict)}\n",
+        "\n",
+        "      #copy iso column\n",
+        "      df[\"S\"] = df[\"iso\"]\n",
+        "\n",
+        "      #map the ratios in the dictionary to the iso column vallues \n",
+        "      df[\"S\"].map(ratio).fillna(df[\"S\"])\n",
+        "\n",
+        "  # Scaling linestrength with the equations from Rotham's paper\n",
+        "  line_strength = df.int * (df.S)\n",
+        "  line_strength *= exp(-hc_k * df.El * (1 / Tgas - 1 / Tref))\n",
+        "  line_strength *= (1 - exp(-hc_k * df.wav / Tgas)) / (\n",
+        "      1 - exp(-hc_k * df.wav / Tref)\n",
+        "  )\n",
+        "  # Add a fresh columns with the scaled linestrength\n",
+        "  df[\"S\"] = line_strength  # [cm-1/(molecules/cm-2)]\n",
+        "\n",
+        "  # Just to make sure linestrength is indeed added\n",
+        "  assert \"S\" in df\n",
+        "\n",
+        "  return df"
+      ],
+      "execution_count": 85,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "He6qk5IDaPGD"
+      },
+      "source": [
+        "### Fetch Hitemp\n",
+        "\n",
+        "I am using HITEMP-CH4 to test this. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "QWVk0nAGaPGE",
+        "outputId": "64e29473-8b7e-4f46-a5a3-f9d138d60792"
+      },
+      "source": [
+        "Tref = 296 # The reference temperature is constant throughout radis\n",
+        "\n",
+        "df0 = fetch_hitemp(molecule='CH4', databank_name='HITEMP-CH4', isotope='1, 2, 3', load_wavenum_min=2000, load_wavenum_max=3000)\n",
+        "\n",
+        "print(\"================Before computation=====================\")\n",
+        "print(df0.head())\n",
+        "\n",
+        "Tgas = 300 # Any temperature of your choice at which you would like to scale linestrength\n",
+        "\n",
+        "%time df0 = calc_linestrength_eq(df0, Tref, Tgas)\n",
+        "\n",
+        "print(\"================After computation Old=====================\")\n",
+        "print(df0.head())\n",
+        "df0.info(verbose=False, memory_usage=\"deep\")"
+      ],
+      "execution_count": 89,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Using existing database HITEMP-CH4\n",
+            "================Before computation=====================\n",
+            "       id  iso         wav           int  ...          iref  lmix     gp    gpp\n",
+            "87326   6    1  2000.00250  2.852000e-42  ...  715947141313          0.0    0.0\n",
+            "87327   6    1  2000.00250  8.171000e-36  ...  715947141313          0.0    0.0\n",
+            "87328   6    1  2000.00264  3.091000e-37  ...  705832 3 3 3        255.0  245.0\n",
+            "87329   6    1  2000.00362  1.880000e-31  ...  705832 3 3 3        123.0  117.0\n",
+            "87330   6    1  2000.00375  1.288000e-39  ...  705832 3 3 3         90.0   86.0\n",
+            "\n",
+            "[5 rows x 19 columns]\n",
+            "Scaling equilibrium linestrength\n",
+            "CPU times: user 1.02 s, sys: 29.7 ms, total: 1.05 s\n",
+            "Wall time: 982 ms\n",
+            "================After computation Old=====================\n",
+            "       id  iso         wav  ...        Qref      Qgas             S\n",
+            "87326   6    1  2000.00250  ...  590.477738  602.8155  5.820099e-42\n",
+            "87327   6    1  2000.00250  ...  590.477738  602.8155  1.292129e-35\n",
+            "87328   6    1  2000.00264  ...  590.477738  602.8155  4.956589e-37\n",
+            "87329   6    1  2000.00362  ...  590.477738  602.8155  2.444609e-31\n",
+            "87330   6    1  2000.00375  ...  590.477738  602.8155  2.261429e-39\n",
+            "\n",
+            "[5 rows x 22 columns]\n",
+            "<class 'pandas.core.frame.DataFrame'>\n",
+            "Int64Index: 2042974 entries, 87326 to 30299\n",
+            "Columns: 22 entries, id to S\n",
+            "dtypes: float64(13), int64(2), object(7)\n",
+            "memory usage: 1.2 GB\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "AdCldcC0zkZx",
+        "outputId": "af7b174a-c19b-42eb-f9f5-05dd5d530e62"
+      },
+      "source": [
+        "df1 = fetch_hitemp(molecule='CH4', databank_name='HITEMP-CH4', isotope='1, 2, 3', load_wavenum_min=2000, load_wavenum_max=3000)\n",
+        "\n",
+        "%time df1 = calc_linestrength_eq_optimised(df1, Tref, Tgas)\n",
+        "\n",
+        "print(\"================After computation Optimised (?)=====================\")\n",
+        "print(df1.head())\n",
+        "df1.info(verbose=False, memory_usage=\"deep\")"
+      ],
+      "execution_count": 90,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Using existing database HITEMP-CH4\n",
+            "not Qref here\n",
+            "Scaling equilibrium linestrength\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/ipykernel_launcher.py:53: RuntimeWarning: invalid value encountered in double_scalars\n"
+          ],
+          "name": "stderr"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "not Qref here\n",
+            "CPU times: user 425 ms, sys: 3.05 ms, total: 428 ms\n",
+            "Wall time: 385 ms\n",
+            "================After computation Optimised (?)=====================\n",
+            "       id  iso         wav           int  ...  lmix     gp    gpp             S\n",
+            "87326   6    1  2000.00250  2.852000e-42  ...          0.0    0.0  5.941707e-42\n",
+            "87327   6    1  2000.00250  8.171000e-36  ...          0.0    0.0  1.319127e-35\n",
+            "87328   6    1  2000.00264  3.091000e-37  ...        255.0  245.0  5.060155e-37\n",
+            "87329   6    1  2000.00362  1.880000e-31  ...        123.0  117.0  2.495688e-31\n",
+            "87330   6    1  2000.00375  1.288000e-39  ...         90.0   86.0  2.308681e-39\n",
+            "\n",
+            "[5 rows x 20 columns]\n",
+            "<class 'pandas.core.frame.DataFrame'>\n",
+            "Int64Index: 2042974 entries, 87326 to 30299\n",
+            "Columns: 20 entries, id to S\n",
+            "dtypes: float64(11), int64(2), object(7)\n",
+            "memory usage: 1.1 GB\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "qxR-inOS3aFj"
+      },
+      "source": [
+        ""
+      ],
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
I have made a few modifications to the way we are handling `Qgas` and `Qref` this reduces the memory by around 100MB while processing lines in the wavenumber range `2000-3000` for the case of `HITEMP-CH4` databank. This also reduces the CPU time [edit EP : of the calc_linestrength_method]   to half  .  

@erwanp if you approve of this method I will implement this into my [PR in the main repo](https://github.com/radis/radis/pull/287).  

Btw, I guess it would be good to add the changes to the databank path we need to make before running the benchmarks in the readme. 